### PR TITLE
chore: update java version to 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 
 
   <properties>
-    <java.version>6</java.version>
+    <java.version>7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.release>${java.version}</maven.compiler.release>


### PR DESCRIPTION
On pull, mvn compile doesn't work, unless the version is bumped to 7