### PR TITLE
updating to jetty 11.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
 
   <properties>
     <java.version>17</java.version>
+    <jetty.version>11.0.9</jetty.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.release>${java.version}</maven.compiler.release>
@@ -174,9 +175,14 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.tomcat.maven</groupId>
-        <artifactId>tomcat7-maven-plugin</artifactId>
-        <version>2.2</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>${jetty.version}</version>
+        <configuration>
+          <webApp>
+            <contextPath>/stms</contextPath>
+          </webApp>
+        </configuration>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
tomcat7-maven-plugin is from 2013 and has many CVE's against it. Also the application context does not startup when I try to use it. Update to embedded jetty 11.0.9 and things work as expected. 